### PR TITLE
Update README.md : conversion syntaxe HTML en Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
 # NSI-SqliteOnline
 
-<p>Here are just a few files to build exercices on SQL DB. It is powered by <a href="https://sql.js.org/">SQLite compiled to JavaScript</a>. There are a few examples available <a href="http://nsi.colbert.bzh/sql">here.</a></p>
-<p>Just add two files into the folder named TP<p>
-<ul>
-<li>a sqlite file width ".sql" extension to init the database</li>
-<li>a html file width ".html" extension for the text of the exercice</li>
-</ul> 
-<p>Then just use a link such as tp.html?text=htmlFileName&db=sqlFileName (for instance tp.html?html=locations_1&db=locations</p>
-Good Luck.
-<br><br>
-Ces données sont mises à disposition selon les termes de la <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Licence Creative Commons Attribution 4.0 International</a>
+Here are just a few files to build exercices on SQL DB. It is powered by [SQLite compiled to JavaScript](https://sql.js.org/).
+There are a few examples available [here online](http://nsi.colbert.bzh/sql).
 
-<h4>Spécificités des fichiers html</h4>
-<p>Les questions sont définies dans des 'div' de classe 'question' incluant de manière optionnelle une solution dans un 'pre' de classe 'response'. Dans le cas
-de réponse à fournir sous forme de phrase, il faut ajouter la classe 'text'</p>
+Just add two files into the folder named `TP`:
 
-<p>&lt;div class='question sql'&gt;<br />D&eacute;terminez le nombre de voitures que vous poss&eacute;dez.<br />&lt;pre class='response'&gt;SELECT COUNT(*) FROM Vehicules&lt;/pre&gt;<br />&lt;/div&gt;<br /><br/>&lt;div class='question text'&gt;<br />Quel ordre de grandeur peuvent atteindre les bases de donn&eacute;es actuelles ?<br />&lt;pre class='response'&gt;Le p&eacute;taoctet. Un p&eacute;taoctet vaut un million de milliards d&rsquo;octets.&lt;/pre&gt;<br />&lt;/div&gt;</p>
+- A SQLite file with `".sql"` extension to initialize the database ;
+- A HTML file with `".html"`, extension for the text of the exercice (see instructions below).
 
+Then just use a link such as `tp.html?text=htmlFileName&db=sqlFileName`, which loads both files (for instance: `tp.html?html=locations_1&db=locations`). Good Luck.
+
+## Spécificités des fichiers HTML
+
+Les questions sont définies dans des `<div>` de classe `question` incluant de manière optionnelle une solution dans un `<pre>` de classe `response`. Dans le cas de réponse à fournir sous forme de phrase, il faut ajouter la classe `text`, comme dans les exemples ci-dessous :
+
+```html
+<div class='question sql'>
+Déterminez le nombre de voitures que vous possédez.
+<pre class='response'>SELECT COUNT(*) FROM Vehicules</pre>
+</div>
+
+<div class='question text'>
+Quel ordre de grandeur peuvent atteindre les bases de données actuelles ?
+<pre class='response'>Le pétaoctet. Un pétaoctet vaut un million de milliards d’octets.</pre>
+</div>
+```
+
+## Licence
+Ces données sont mises à disposition selon les termes de la [Licence Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
Bonjour et merci pour ce chouette projet !
(découvert grâce à ton email sur la liste NSI)

J'ai converti la syntaxe de ce README.md en Markdown, c'est notamment utile pour afficher l'exemple de HTML bien joliment :smiley:.

Note : Il faudrait aussi ajouter un fichier LICENSE, pour que GitHub affichage automatiquement que le projet est distribué sous licence CC.